### PR TITLE
Type is required two times.

### DIFF
--- a/entry-tp.schema.json
+++ b/entry-tp.schema.json
@@ -360,7 +360,7 @@
                     "type": "string"
                 }
             },
-            "required": ["id", "name", "format", "type", "type", "valueChoices", "valueType", "valueStateId"]
+            "required": ["id", "name", "format", "type", "valueChoices", "valueType", "valueStateId"]
         },
 
         "connector": {


### PR DESCRIPTION
https://www.jsonschemavalidator.net/ complains about missing property, even if type is set.
When removing the duplicate, it stops complaining.